### PR TITLE
Reuse socket address

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var os = require('os')
 module.exports = function (port, loopback) {
 
   var addresses = {}
-  var socket = udp.createSocket('udp4')
+  var socket = udp.createSocket({type: udp4, reuseAddr: true})
 
   process.on('exit', function () {
     socket.dropMembership('255.255.255.255')


### PR DESCRIPTION
Enable reuseAddr so that multiple instances can listen on the same port locally